### PR TITLE
Add elektroda forum feature to random questions

### DIFF
--- a/source/bot.py
+++ b/source/bot.py
@@ -6,7 +6,6 @@ from discord.ext.commands import CommandNotFound
 from discord.ext.commands import cooldown, BucketType, CommandOnCooldown
 
 from dotenv import load_dotenv
-from random import randint
 
 from .commands.check_baca import check_baca
 from .commands.remindme import remindme_util
@@ -97,15 +96,11 @@ class Bot(BotBase):
             if len(message.content) == 0 or message.content[0] == self.PREFIX:
                 return
 
-            nickname = message.author.display_name
             response = get_text(message.content, message.author)
-
-            if response["text"] is not None:
+            if response is not None:
                 await send_response(response, message, message.author)
                 if response["delete"] is True:
                     await message.delete()
-            elif randint(1, 4000) >= 3999:
-                await send_response(nickname, message, message.author, True)
 
 
 bot = Bot()

--- a/source/response_utils/get_text.py
+++ b/source/response_utils/get_text.py
@@ -1,3 +1,4 @@
+from random import randint
 import re
 from typing import Optional, Dict
 from datetime import datetime
@@ -23,7 +24,7 @@ def get_text(message: str, author=None) -> Optional[Dict[str, bool]]:
 
     regx = re.search(r"([\s\S]*)bocie", message, re.IGNORECASE)
     if regx is not None:
-        response["text"] = f"{regx.group(1)}{author}"
+        response["text"] = f"{regx.group(1)}{author.display_name}"
         response["image"] = True
         return response
 
@@ -37,9 +38,16 @@ def get_text(message: str, author=None) -> Optional[Dict[str, bool]]:
 
     regx = re.search(r"<:deprecatedDelevoCry:[0-9]*>", message)
     if regx is not None:
-        response["text"] = ""
         response["text"] = f"----------\n[{datetime.today().strftime('%Y-%m-%d %H:%M:%S')}] WARNING: Deprecated emoji call.\n <:deprecatedDelevoCry:917741279012610078> is deprecated.\n{author.mention} please use the new <:baniaCry:1067860950700531842> cry emoji instead.\n----------"
-        response["mention"] = True
         return response
 
-    return response
+    regx = re.search(r"\?$", message, re.IGNORECASE)
+    if regx is not None and randint(1, 400) >= 399:
+        response["text"] = f"{author.mention} jako, że jesteś nowy to tym razem skończy się tylko na warnie ale w przyszłości UŻYJ OPCJI SZUKAJ, było wałkowane milion razy. Pozdrawiam, moderator forum."
+        return response
+
+    if randint(1, 4000) >= 3999:
+        response["text"] = message + f" {author.display_name}"
+        return response
+
+    return None

--- a/source/response_utils/image_generator.py
+++ b/source/response_utils/image_generator.py
@@ -30,7 +30,7 @@ def contains_polish_letters(text: str) -> str:
     return re.search(r"[żółćęśąźń]", text) is not None
 
 
-def create_image(response: dict[str, bool, bool], author: str) -> Image:
+def create_image(response: dict[str, bool], author) -> Image:
     text = response["text"]
     fontsize = 40 if len(text) > 100 else 80
 

--- a/source/response_utils/send_response.py
+++ b/source/response_utils/send_response.py
@@ -5,14 +5,14 @@ from .image_generator import create_image
 
 
 async def send_response(
-    response: dict[str, bool], context, author: str,
+    response: dict[str, bool], message, author,
 ) -> None:
     if response["image"]:
         with BytesIO() as image_binary:
             create_image(response, author).save(image_binary, "PNG")
             image_binary.seek(0)
-            await context.channel.send(
+            await message.channel.send(
                 file=discord.File(fp=image_binary, filename="image.png")
             )
     else:
-        await context.channel.send(response["text"])
+        await message.channel.send(response["text"])

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -3,143 +3,142 @@ import re
 
 
 def test_get_text():
+    class Author:
+        def __init__(self, name="author"):
+            self.display_name = name
+
+        def mention(self) -> str:
+            return self.display_name
+
     text_none = ""
-    assert get_text(text_none) == {
-        "text": None,
-        "delete": False,
-        "add_ok": False,
-        "image": False,
-    }
+    assert get_text(text_none) is None
 
     text_wrong = "abc"
-    assert get_text(text_wrong) == {
-        "text": None,
-        "delete": False,
-        "add_ok": False,
-        "image": False,
-    }
+    assert get_text(text_wrong) is None
 
-    text_1 = ";okabc;"
-    assert get_text(text_1) == {
+    text_lowercasePrintCommand = ";okabc;"
+    assert get_text(text_lowercasePrintCommand) == {
         "text": "abc",
         "delete": True,
         "add_ok": True,
         "image": True,
     }
-    text_2 = ";Okabc;"
-    assert get_text(text_2) == {
-        "text": "abc",
-        "delete": True,
-        "add_ok": True,
-        "image": True,
-    }
-
-    text_3 = ";oKabc;"
-    assert get_text(text_3) == {
+    text_capitalizedPrintCommand = ";Okabc;"
+    assert get_text(text_capitalizedPrintCommand) == {
         "text": "abc",
         "delete": True,
         "add_ok": True,
         "image": True,
     }
 
-    text_4 = ";OKabc;"
-    assert get_text(text_4) == {
+    text_pokemonStylePrintCommand = ";oKabc;"
+    assert get_text(text_pokemonStylePrintCommand) == {
         "text": "abc",
         "delete": True,
         "add_ok": True,
         "image": True,
     }
 
-    text_5 = ";okabc ;"
-    assert get_text(text_5) == {
+    text_uppercaseOKPrintCommand = ";OKabc;"
+    assert get_text(text_uppercaseOKPrintCommand) == {
+        "text": "abc",
+        "delete": True,
+        "add_ok": True,
+        "image": True,
+    }
+
+    text_whitespaceOnEndOfPrintCommand = ";okabc ;"
+    assert get_text(text_whitespaceOnEndOfPrintCommand) == {
         "text": "abc ",
         "delete": True,
         "add_ok": True,
         "image": True,
     }
 
-    text_6 = ";ok abc;"
-    assert get_text(text_6) == {
+    text_whitespaceInPrintCommand = ";ok abc;"
+    assert get_text(text_whitespaceInPrintCommand) == {
         "text": " abc",
         "delete": True,
         "add_ok": True,
         "image": True,
     }
 
-    text_7 = "cześć bocie"
-    author = "bejbe"
-    assert get_text(text_7, author) == {
+    text_bocieCommand = "cześć bocie"
+    author = Author("bejbe")
+    assert get_text(text_bocieCommand, author) == {
         "text": "cześć bejbe",
         "delete": False,
         "add_ok": False,
         "image": True,
     }
 
-    text_8 = ";ok~abc;"
-    assert get_text(text_8) == {
+    text_singleTildePrintCommand = ";ok~abc;"
+    assert get_text(text_singleTildePrintCommand) == {
         "text": "abc",
         "delete": False,
         "add_ok": True,
         "image": True,
     }
 
-    text_9 = ";ok~~abc;"
-    assert get_text(text_9) == {
+    text_doubleTildePrintCommand = ";ok~~abc;"
+    assert get_text(text_doubleTildePrintCommand) == {
         "text": "abc",
         "delete": True,
         "add_ok": False,
         "image": True,
     }
 
-    text_10 = ";ok~~~abc;"
-    assert get_text(text_10) == {
+    text_tripleTildePrintCommand = ";ok~~~abc;"
+    assert get_text(text_tripleTildePrintCommand) == {
         "text": "abc",
         "delete": False,
         "add_ok": False,
         "image": True,
     }
 
-    text_11 = "bocie"
-    assert get_text(text_11, "author") == {
+    author = Author()
+
+    text_standaloneBocieCommand = "bocie"
+    assert get_text(text_standaloneBocieCommand, author) == {
         "text": "author",
         "delete": False,
         "add_ok": False,
         "image": True,
     }
 
-    text_12 = ":deprecatedDelevoCry:"
-    response = get_text(text_12)
-    assert response["text"] is None
-    assert response["delete"] is False
-    assert response["add_ok"] is False
-    assert response["image"] is False
+    text_lowercaseWrongDeprecated = ":deprecatedDelevoCry:"
+    response = get_text(text_lowercaseWrongDeprecated)
+    assert response is None
 
-    text_13 = ":DeprecatedDelevoCry:"
-    response = get_text(text_13)
-    assert response["text"] is None
-    assert response["delete"] is False
-    assert response["add_ok"] is False
-    assert response["image"] is False
+    text_uppercaseWrongDeprecated = ":DeprecatedDelevoCry:"
+    response = get_text(text_uppercaseWrongDeprecated)
+    assert response is None
 
-    text_14 = "deprecatedDelevoCry"
-    response = get_text(text_14)
-    assert response["text"] is None
-    assert response["delete"] is False
-    assert response["add_ok"] is False
-    assert response["image"] is False
+    text_noColonsWrongDeprecated = "deprecatedDelevoCry"
+    response = get_text(text_noColonsWrongDeprecated)
+    assert response is None
 
-    text_15 = "<:deprecatedDelevoCry:123456789>"
-
-    class Author:
-        def mention(self) -> str:
-            return "author"
-
+    text_correctDeprecated = "<:deprecatedDelevoCry:123456789>"
     author = Author()
-
-    response = get_text(text_15, author)
+    response = get_text(text_correctDeprecated, author)
     assert response["text"] is not None
     assert response["delete"] is False
     assert response["add_ok"] is False
     assert response["image"] is False
     assert re.search(r"WARNING: Deprecated emoji call",
                      response["text"]) is not None
+
+    test_correctElektroda = "pytanie?"
+    author = Author()
+    response = get_text(test_correctElektroda, author)
+    assert response is None or \
+        response["delete"] is False and \
+        response["add_ok"] is False and \
+        response["image"] is False and \
+        re.search(
+            r"jako, że jesteś nowy to tym razem skończy się tylko na warnie ale w przyszłości UŻYJ OPCJI SZUKAJ, było wałkowane milion razy\. Pozdrawiam, moderator forum\.", response["text"]) is not None
+
+    test_incorrectElektroda = "pytanie? "
+    author = Author()
+    response = get_text(test_incorrectElektroda, author)
+    assert response is None


### PR DESCRIPTION
- Adding a new feature **elektroda forum** which is a small chance of a rude reply to a posted question.
- Moved existing random message feature to `get_response`.
- In case of no eligible response to produce `get_response` now simply returns `None`.
- Renamed test cases for readability.
- Remove dead code from message sending module that came from **deprecatedDelevoCry** feature.
- Fixed a bug regarding using `author` instead of `author.display_name` in some cases.
- Renamed `context` to `message` in `send_response` for better readability.